### PR TITLE
moved settings to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ node_modules/
 
 # Local configuration files
 config.local.*
+config.local.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1600,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1871,6 +1921,7 @@ dependencies = [
  "serde_json",
  "syntect",
  "tokio",
+ "toml",
  "url",
  "urlencoding",
  "uuid",
@@ -2110,6 +2161,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { version = "^0.4", features = ["serde"] }
 colored = "^3.0"
 indicatif = "^0.18"
 anyhow = "^1.0"
+toml = "^0.8"
 url = "^2.4"
 urlencoding = "^2.1"
 syntect = "^5.0"

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -18,7 +18,7 @@ webhook logs --token YOUR_TOKEN --count 20
 ```bash
 # In your test script:
 TOKEN=$(webhook generate | grep "Token:" | cut -d' ' -f2)
-echo "Testing webhook: https://webhooktest.emergemarket.dev/$TOKEN"
+echo "Testing webhook: $TOKEN"
 
 # Run your tests that send webhooks...
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,41 @@ A fast, efficient command-line tool for webhook testing and monitoring built in 
 - 🎨 **Colorized Output**: Beautiful, readable colored terminal output
 - ⚡ **Low Resource Usage**: Minimal CPU and memory footprint
 
+## Configuration
+
+The tool uses configuration files to manage settings, including the webhook service URL. This allows you to keep internal URLs out of your source code repository.
+
+### Configuration Files
+
+1. **`config.toml`** - Default configuration template (safe to commit)
+2. **`config.local.toml`** - Local configuration with internal URLs (NOT committed to repository)
+
+### Setting Up Configuration
+
+1. **Copy the template:**
+   ```bash
+   cp config.toml config.local.toml
+   ```
+
+2. **Edit `config.local.toml` with your internal settings:**
+   ```toml
+   [webhook]
+   base_url = "https://your-internal-webhook-service.com"
+   default_count = 10
+   default_interval = 3
+   show_headers_by_default = false
+   show_full_body_by_default = false
+   ```
+
+3. **The `config.local.toml` file is automatically ignored by git**
+
+### Configuration Priority
+
+The tool loads configuration in this order:
+1. `config.local.toml` (highest priority)
+2. `config.toml` (fallback)
+3. Built-in defaults (if no config files exist)
+
 ## Installation
 
 ### Prerequisites
@@ -45,7 +80,7 @@ Output:
 🔑 New webhook token generated!
 
 Token: 123e4567-e89b-12d3-a456-426614174000
-Webhook URL: https://webhooktest.emergemarket.dev/123e4567-e89b-12d3-a456-426614174000
+Webhook URL: https://your-webhook-service.com/123e4567-e89b-12d3-a456-426614174000
 
 💡 Usage examples:
   webhook monitor --token 123e4567-e89b-12d3-a456-426614174000
@@ -251,6 +286,12 @@ User-Agent: MyApp/1.0
 - **Server Monitoring**: Lightweight webhook monitoring on servers
 - **Scripting**: Integrate webhook monitoring into shell scripts
 - **Remote Development**: SSH-friendly webhook testing
+
+## Security Notes
+
+- Never commit `config.local.toml` to version control
+- The `config.local.toml` file is automatically added to `.gitignore`
+- Use environment variables or secure configuration management for production deployments
 
 ## Contributing
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,14 @@
+# Webhook CLI Configuration
+# Copy this file to config.local.toml and modify the values as needed
+
+[webhook]
+# Base URL for the webhook service
+base_url = "https://your-webhook-service.com"
+
+# Default settings
+default_count = 10
+default_interval = 3
+
+# Display settings
+show_headers_by_default = false
+show_full_body_by_default = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,71 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Config {
+    pub webhook: WebhookConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WebhookConfig {
+    pub base_url: String,
+    pub default_count: u32,
+    pub default_interval: u64,
+    pub show_headers_by_default: bool,
+    pub show_full_body_by_default: bool,
+}
+
+impl Config {
+    pub fn load() -> Result<Self> {
+        // Try to load from local config first, then fall back to default config
+        let config_paths = [
+            "config.local.toml",
+            "config.toml",
+        ];
+
+        for path in config_paths {
+            if Path::new(path).exists() {
+                let content = fs::read_to_string(path)
+                    .with_context(|| format!("Failed to read config file: {}", path))?;
+                
+                let config: Config = toml::from_str(&content)
+                    .with_context(|| format!("Failed to parse config file: {}", path))?;
+                
+                return Ok(config);
+            }
+        }
+
+        // If no config file exists, create a default one and return default values
+        let default_config = Config {
+            webhook: WebhookConfig {
+                base_url: "https://your-webhook-service.com".to_string(),
+                default_count: 10,
+                default_interval: 3,
+                show_headers_by_default: false,
+                show_full_body_by_default: false,
+            },
+        };
+
+        // Create the default config file
+        let default_content = toml::to_string_pretty(&default_config)
+            .context("Failed to serialize default config")?;
+        fs::write("config.toml", default_content)
+            .context("Failed to write default config file")?;
+
+        Ok(default_config)
+    }
+
+    pub fn get_base_url(&self) -> &str {
+        &self.webhook.base_url
+    }
+
+    pub fn get_default_count(&self) -> u32 {
+        self.webhook.default_count
+    }
+
+    pub fn get_default_interval(&self) -> u64 {
+        self.webhook.default_interval
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ use std::collections::HashMap;
 use std::time::Duration;
 use uuid::Uuid;
 
+mod config;
+use config::Config;
+
 #[derive(Parser)]
 #[command(name = "webhook")]
 #[command(about = "A CLI tool for webhook testing and monitoring")]
@@ -106,10 +109,10 @@ struct WebhookClient {
 }
 
 impl WebhookClient {
-    fn new() -> Self {
+    fn new(config: &Config) -> Self {
         Self {
             client: Client::new(),
-            base_url: "https://webhooktest.emergemarket.dev".to_string(),
+            base_url: config.get_base_url().to_string(),
         }
     }
 
@@ -140,12 +143,13 @@ impl WebhookClient {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    let client = WebhookClient::new();
+    let config = Config::load()?;
+    let client = WebhookClient::new(&config);
 
     match cli.command {
         Commands::Generate => {
             let token = Uuid::new_v4();
-            let webhook_url = format!("https://webhooktest.emergemarket.dev/{}", token);
+            let webhook_url = format!("{}/{}", config.get_base_url(), token);
             
             println!("{}", "🔑 New webhook token generated!".bright_green().bold());
             println!();
@@ -166,7 +170,7 @@ async fn main() -> Result<()> {
                     let new_token = Uuid::new_v4();
                     println!("{}", "🔑 No token provided, generated a new one:".bright_yellow());
                     println!("{}: {}", "Token".bright_blue().bold(), new_token.to_string().bright_white());
-                    println!("{}: https://webhooktest.emergemarket.dev/{}", "Webhook URL".bright_blue().bold(), new_token.to_string().bright_white());
+                    println!("{}: {}/{}", "Webhook URL".bright_blue().bold(), config.get_base_url(), new_token.to_string().bright_white());
                     println!();
                     new_token.to_string()
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable settings via config.toml with automatic creation of a default config if none exists.
  - CLI now uses the configured base URL for all generated and displayed webhook URLs.
  - Introduced defaults for request count and interval.

- Documentation
  - Added Configuration and Security Notes sections.
  - Updated examples to use a generic internal domain.
  - Minor formatting improvements.

- Chores
  - Ignored local configuration file (config.local.toml) to prevent accidental commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->